### PR TITLE
hdfs-writer添加hadoop-hdfs.jar

### DIFF
--- a/plugin/writer/hdfswriter/pom.xml
+++ b/plugin/writer/hdfswriter/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
- hdfs-writer添加hadoop-hdfs.jar，修复ha配置以及k8s认证情况下写入失败问题